### PR TITLE
Create project files to commence TDD...

### DIFF
--- a/ArgusCoreVideo/ArgusCoreVideo.xcodeproj/project.pbxproj
+++ b/ArgusCoreVideo/ArgusCoreVideo.xcodeproj/project.pbxproj
@@ -1,0 +1,458 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CA1EF4FC2131BDE000A791E9 /* ArgusCoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA1EF4F22131BDDF00A791E9 /* ArgusCoreVideo.framework */; };
+		CA1EF5012131BDE000A791E9 /* ArgusCoreVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1EF5002131BDE000A791E9 /* ArgusCoreVideoTests.swift */; };
+		CA1EF5032131BDE000A791E9 /* ArgusCoreVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1EF4F52131BDE000A791E9 /* ArgusCoreVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CA1EF4FD2131BDE000A791E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CA1EF4E92131BDDF00A791E9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CA1EF4F12131BDDF00A791E9;
+			remoteInfo = ArgusCoreVideo;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		CA1EF4F22131BDDF00A791E9 /* ArgusCoreVideo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ArgusCoreVideo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA1EF4F52131BDE000A791E9 /* ArgusCoreVideo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArgusCoreVideo.h; sourceTree = "<group>"; };
+		CA1EF4F62131BDE000A791E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CA1EF4FB2131BDE000A791E9 /* ArgusCoreVideoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArgusCoreVideoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA1EF5002131BDE000A791E9 /* ArgusCoreVideoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgusCoreVideoTests.swift; sourceTree = "<group>"; };
+		CA1EF5022131BDE000A791E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CA1EF4EE2131BDDF00A791E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA1EF4F82131BDE000A791E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA1EF4FC2131BDE000A791E9 /* ArgusCoreVideo.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CA1EF4E82131BDDF00A791E9 = {
+			isa = PBXGroup;
+			children = (
+				CA1EF4F42131BDDF00A791E9 /* ArgusCoreVideo */,
+				CA1EF4FF2131BDE000A791E9 /* ArgusCoreVideoTests */,
+				CA1EF4F32131BDDF00A791E9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CA1EF4F32131BDDF00A791E9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CA1EF4F22131BDDF00A791E9 /* ArgusCoreVideo.framework */,
+				CA1EF4FB2131BDE000A791E9 /* ArgusCoreVideoTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CA1EF4F42131BDDF00A791E9 /* ArgusCoreVideo */ = {
+			isa = PBXGroup;
+			children = (
+				CA1EF4F52131BDE000A791E9 /* ArgusCoreVideo.h */,
+				CA1EF4F62131BDE000A791E9 /* Info.plist */,
+			);
+			path = ArgusCoreVideo;
+			sourceTree = "<group>";
+		};
+		CA1EF4FF2131BDE000A791E9 /* ArgusCoreVideoTests */ = {
+			isa = PBXGroup;
+			children = (
+				CA1EF5002131BDE000A791E9 /* ArgusCoreVideoTests.swift */,
+				CA1EF5022131BDE000A791E9 /* Info.plist */,
+			);
+			path = ArgusCoreVideoTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		CA1EF4EF2131BDDF00A791E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA1EF5032131BDE000A791E9 /* ArgusCoreVideo.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		CA1EF4F12131BDDF00A791E9 /* ArgusCoreVideo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA1EF5062131BDE000A791E9 /* Build configuration list for PBXNativeTarget "ArgusCoreVideo" */;
+			buildPhases = (
+				CA1EF4ED2131BDDF00A791E9 /* Sources */,
+				CA1EF4EE2131BDDF00A791E9 /* Frameworks */,
+				CA1EF4EF2131BDDF00A791E9 /* Headers */,
+				CA1EF4F02131BDDF00A791E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ArgusCoreVideo;
+			productName = ArgusCoreVideo;
+			productReference = CA1EF4F22131BDDF00A791E9 /* ArgusCoreVideo.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CA1EF4FA2131BDE000A791E9 /* ArgusCoreVideoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA1EF5092131BDE000A791E9 /* Build configuration list for PBXNativeTarget "ArgusCoreVideoTests" */;
+			buildPhases = (
+				CA1EF4F72131BDE000A791E9 /* Sources */,
+				CA1EF4F82131BDE000A791E9 /* Frameworks */,
+				CA1EF4F92131BDE000A791E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CA1EF4FE2131BDE000A791E9 /* PBXTargetDependency */,
+			);
+			name = ArgusCoreVideoTests;
+			productName = ArgusCoreVideoTests;
+			productReference = CA1EF4FB2131BDE000A791E9 /* ArgusCoreVideoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CA1EF4E92131BDDF00A791E9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0940;
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = pajato;
+				TargetAttributes = {
+					CA1EF4F12131BDDF00A791E9 = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+					CA1EF4FA2131BDE000A791E9 = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+				};
+			};
+			buildConfigurationList = CA1EF4EC2131BDDF00A791E9 /* Build configuration list for PBXProject "ArgusCoreVideo" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = CA1EF4E82131BDDF00A791E9;
+			productRefGroup = CA1EF4F32131BDDF00A791E9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CA1EF4F12131BDDF00A791E9 /* ArgusCoreVideo */,
+				CA1EF4FA2131BDE000A791E9 /* ArgusCoreVideoTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CA1EF4F02131BDDF00A791E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA1EF4F92131BDE000A791E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CA1EF4ED2131BDDF00A791E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA1EF4F72131BDE000A791E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA1EF5012131BDE000A791E9 /* ArgusCoreVideoTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CA1EF4FE2131BDE000A791E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CA1EF4F12131BDDF00A791E9 /* ArgusCoreVideo */;
+			targetProxy = CA1EF4FD2131BDE000A791E9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		CA1EF5042131BDE000A791E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		CA1EF5052131BDE000A791E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		CA1EF5072131BDE000A791E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = NYK3FCF3T2;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ArgusCoreVideo/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pajato.ArgusCoreVideo;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CA1EF5082131BDE000A791E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = NYK3FCF3T2;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ArgusCoreVideo/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pajato.ArgusCoreVideo;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CA1EF50A2131BDE000A791E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = NYK3FCF3T2;
+				INFOPLIST_FILE = ArgusCoreVideoTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pajato.ArgusCoreVideoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CA1EF50B2131BDE000A791E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = NYK3FCF3T2;
+				INFOPLIST_FILE = ArgusCoreVideoTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pajato.ArgusCoreVideoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CA1EF4EC2131BDDF00A791E9 /* Build configuration list for PBXProject "ArgusCoreVideo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA1EF5042131BDE000A791E9 /* Debug */,
+				CA1EF5052131BDE000A791E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CA1EF5062131BDE000A791E9 /* Build configuration list for PBXNativeTarget "ArgusCoreVideo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA1EF5072131BDE000A791E9 /* Debug */,
+				CA1EF5082131BDE000A791E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CA1EF5092131BDE000A791E9 /* Build configuration list for PBXNativeTarget "ArgusCoreVideoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA1EF50A2131BDE000A791E9 /* Debug */,
+				CA1EF50B2131BDE000A791E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CA1EF4E92131BDDF00A791E9 /* Project object */;
+}

--- a/ArgusCoreVideo/ArgusCoreVideo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ArgusCoreVideo/ArgusCoreVideo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ArgusCoreVideo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ArgusCoreVideo/ArgusCoreVideo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ArgusCoreVideo/ArgusCoreVideo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ArgusCoreVideo/ArgusCoreVideo/ArgusCoreVideo.h
+++ b/ArgusCoreVideo/ArgusCoreVideo/ArgusCoreVideo.h
@@ -1,0 +1,19 @@
+//
+//  ArgusCoreVideo.h
+//  ArgusCoreVideo
+//
+//  Created by Paul Reilly on 8/25/18.
+//  Copyright © 2018 pajato. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for ArgusCoreVideo.
+FOUNDATION_EXPORT double ArgusCoreVideoVersionNumber;
+
+//! Project version string for ArgusCoreVideo.
+FOUNDATION_EXPORT const unsigned char ArgusCoreVideoVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ArgusCoreVideo/PublicHeader.h>
+
+

--- a/ArgusCoreVideo/ArgusCoreVideo/Info.plist
+++ b/ArgusCoreVideo/ArgusCoreVideo/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/ArgusCoreVideo/ArgusCoreVideoTests/ArgusCoreVideoTests.swift
+++ b/ArgusCoreVideo/ArgusCoreVideoTests/ArgusCoreVideoTests.swift
@@ -1,0 +1,24 @@
+//
+//  ArgusCoreVideoTests.swift
+//  ArgusCoreVideoTests
+//
+//  Created by Paul Reilly on 8/25/18.
+//  Copyright © 2018 pajato. All rights reserved.
+//
+
+import XCTest
+@testable import ArgusCoreVideo
+
+class ArgusCoreVideoTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+}

--- a/ArgusCoreVideo/ArgusCoreVideoTests/Info.plist
+++ b/ArgusCoreVideo/ArgusCoreVideoTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/notes.org
+++ b/notes.org
@@ -1,0 +1,11 @@
+* Xcode Project Setup
+1) Create a GitHub project ArgusCoreVideoSiX for Swift with an initial README.md file.
+2) Clone the base project to the development system.
+3) Create a Cocoa Touch Framework, ArgusCoreVideo, as a sibling of the .git folder from step 2.
+4) Remove errors and run the tests (CMD-U) to verify the project is basically sane. Should have no errors.
+5) Remove all test code to prepare for start of TDD.
+6) Commit baseline code and notes, generate PR and merge to master.
+7) Start using TDD to implement the use cases using the initial high level design work as a living guide.
+
+* TDD
+** Generate simple tests ...


### PR DESCRIPTION
This push has created and verified the Xcode files, successfully run and removed the default test methods and is now ready to use TDD to implement the Core Video register and find* use cases.